### PR TITLE
Fixed Flaky test: testWithAnnotations and testWithAnnotationsEquals

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.jakarta.rs.cfg;
 
-import java.util.HashMap;
 import java.lang.annotation.Annotation;
 
 /**
@@ -26,7 +25,7 @@ public final class AnnotationBundleKey
     private final boolean _annotationsCopied;
 
     private final int _hashCode;
-    
+
     /*
     /**********************************************************
     /* Construction
@@ -83,7 +82,7 @@ public final class AnnotationBundleKey
         System.arraycopy(_annotations, 0, newAnnotations, 0, len);
         return new AnnotationBundleKey(newAnnotations, _type, _hashCode);
     }
-    
+
     /*
     /**********************************************************
     /* Overridden methods
@@ -109,7 +108,7 @@ public final class AnnotationBundleKey
         if (o == null) return false;
         if (o.getClass() != getClass()) return false;
         AnnotationBundleKey other = (AnnotationBundleKey) o;
-        if (other._type != _type) {
+        if ((other._hashCode != _hashCode) || (other._type != _type)) {
             return false;
         }
         return _equals(other._annotations);
@@ -128,21 +127,32 @@ public final class AnnotationBundleKey
         //   method signature is likely to match. So false negatives are acceptable
         //   over having to do order-insensitive comparison.
 
-        HashMap<Annotation, Integer> frequencyMap = new HashMap<>();
+        switch (len) {
+            default:
+                for (int i = 0; i < len; ++i) {
+                    if (!_annotations[i].equals(otherAnn[i])) {
+                        return false;
+                    }
+                }
+                return true;
 
-        for (Annotation ann: _annotations) {
-            frequencyMap.put(ann, frequencyMap.getOrDefault(ann, 0) + 1);
+            case 3:
+                if (!_annotations[2].equals(otherAnn[2])) {
+                    return false;
+                }
+                // fall through
+            case 2:
+                if (!_annotations[1].equals(otherAnn[1])) {
+                    return false;
+                }
+                // fall through
+            case 1:
+                if (!_annotations[0].equals(otherAnn[0])) {
+                    return false;
+                }
+                // fall through
+            case 0:
         }
-
-        for (Annotation ann: otherAnn) {
-            if (!frequencyMap.containsKey(ann)) {
-                return false;
-            }
-            frequencyMap.put(ann, frequencyMap.get(ann) - 1);
-            if (frequencyMap.get(ann) == 0) {
-                frequencyMap.remove(ann);
-            }
-        }
-        return frequencyMap.isEmpty();
+        return true;
     }
 }

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -130,16 +130,14 @@ public final class AnnotationBundleKey
         switch (len) {
         default:
             for (Annotation annotation1 : _annotations) {
-                boolean found = false;
+                boolean notFound = true;
                 for (Annotation annotation2 : otherAnn) {
-                    if (annotation1 == annotation2) {
-                        found = true;
-                        if (!annotation1.equals(annotation2)) {
-                            return false;
-                        }
+                    if (annotation1.equals(annotation2)) {
+                        notFound = false;
+                        break;
                     }
                 }
-                if (!found) {
+                if (notFound) {
                     return false;
                 }
             }

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.jakarta.rs.cfg;
 
+import java.util.HashMap;
 import java.lang.annotation.Annotation;
 
 /**
@@ -25,7 +26,7 @@ public final class AnnotationBundleKey
     private final boolean _annotationsCopied;
 
     private final int _hashCode;
-    
+
     /*
     /**********************************************************
     /* Construction
@@ -82,7 +83,7 @@ public final class AnnotationBundleKey
         System.arraycopy(_annotations, 0, newAnnotations, 0, len);
         return new AnnotationBundleKey(newAnnotations, _type, _hashCode);
     }
-    
+
     /*
     /**********************************************************
     /* Overridden methods
@@ -126,40 +127,22 @@ public final class AnnotationBundleKey
         //   possible permutations but rather trying to ensure that caching of same
         //   method signature is likely to match. So false negatives are acceptable
         //   over having to do order-insensitive comparison.
-        
-        switch (len) {
-        default:
-            for (Annotation annotation1 : _annotations) {
-                boolean notFound = true;
-                for (Annotation annotation2 : otherAnn) {
-                    if (annotation1.equals(annotation2)) {
-                        notFound = false;
-                        break;
-                    }
-                }
-                if (notFound) {
-                    return false;
-                }
-            }
-            return true;
 
-        case 3:
-            if (!_annotations[2].equals(otherAnn[2])) {
-                return false;
-            }
-            // fall through
-        case 2:
-            if (!_annotations[1].equals(otherAnn[1])) {
-                return false;
-            }
-            // fall through
-        case 1:
-            if (!_annotations[0].equals(otherAnn[0])) {
-                return false;
-            }
-            // fall through
-        case 0:
+        HashMap<Annotation, Integer> frequencyMap = new HashMap<>();
+
+        for (Annotation ann: _annotations) {
+            frequencyMap.put(ann, frequencyMap.getOrDefault(ann, 0) + 1);
         }
-        return true;
+
+        for (Annotation ann: otherAnn) {
+            if (!frequencyMap.containsKey(ann)) {
+                return false;
+            }
+            frequencyMap.put(ann, frequencyMap.get(ann) - 1);
+            if (frequencyMap.get(ann) == 0) {
+                frequencyMap.remove(ann);
+            }
+        }
+        return frequencyMap.isEmpty();
     }
 }

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -25,7 +25,7 @@ public final class AnnotationBundleKey
     private final boolean _annotationsCopied;
 
     private final int _hashCode;
-
+    
     /*
     /**********************************************************
     /* Construction
@@ -82,7 +82,7 @@ public final class AnnotationBundleKey
         System.arraycopy(_annotations, 0, newAnnotations, 0, len);
         return new AnnotationBundleKey(newAnnotations, _type, _hashCode);
     }
-
+    
     /*
     /**********************************************************
     /* Overridden methods
@@ -126,32 +126,32 @@ public final class AnnotationBundleKey
         //   possible permutations but rather trying to ensure that caching of same
         //   method signature is likely to match. So false negatives are acceptable
         //   over having to do order-insensitive comparison.
-
+        
         switch (len) {
-            default:
-                for (int i = 0; i < len; ++i) {
-                    if (!_annotations[i].equals(otherAnn[i])) {
-                        return false;
-                    }
-                }
-                return true;
-
-            case 3:
-                if (!_annotations[2].equals(otherAnn[2])) {
+        default:
+            for (int i = 0; i < len; ++i) {
+                if (!_annotations[i].equals(otherAnn[i])) {
                     return false;
                 }
-                // fall through
-            case 2:
-                if (!_annotations[1].equals(otherAnn[1])) {
-                    return false;
-                }
-                // fall through
-            case 1:
-                if (!_annotations[0].equals(otherAnn[0])) {
-                    return false;
-                }
-                // fall through
-            case 0:
+            }
+            return true;
+            
+        case 3:
+            if (!_annotations[2].equals(otherAnn[2])) {
+                return false;
+            }
+            // fall through
+        case 2:
+            if (!_annotations[1].equals(otherAnn[1])) {
+                return false;
+            }
+            // fall through
+        case 1:
+            if (!_annotations[0].equals(otherAnn[0])) {
+                return false;
+            }
+            // fall through
+        case 0:
         }
         return true;
     }

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -108,7 +108,7 @@ public final class AnnotationBundleKey
         if (o == null) return false;
         if (o.getClass() != getClass()) return false;
         AnnotationBundleKey other = (AnnotationBundleKey) o;
-        if ((other._hashCode != _hashCode) || (other._type != _type)) {
+        if (other._type != _type) {
             return false;
         }
         return _equals(other._annotations);
@@ -129,13 +129,22 @@ public final class AnnotationBundleKey
         
         switch (len) {
         default:
-            for (int i = 0; i < len; ++i) {
-                if (!_annotations[i].equals(otherAnn[i])) {
+            for (Annotation annotation1 : _annotations) {
+                boolean found = false;
+                for (Annotation annotation2 : otherAnn) {
+                    if (annotation1 == annotation2) {
+                        found = true;
+                        if (!annotation1.equals(annotation2)) {
+                            return false;
+                        }
+                    }
+                }
+                if (!found) {
                     return false;
                 }
             }
             return true;
-            
+
         case 3:
             if (!_annotations[2].equals(otherAnn[2])) {
                 return false;

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java
@@ -26,7 +26,7 @@ public final class AnnotationBundleKey
     private final boolean _annotationsCopied;
 
     private final int _hashCode;
-
+    
     /*
     /**********************************************************
     /* Construction
@@ -83,7 +83,7 @@ public final class AnnotationBundleKey
         System.arraycopy(_annotations, 0, newAnnotations, 0, len);
         return new AnnotationBundleKey(newAnnotations, _type, _hashCode);
     }
-
+    
     /*
     /**********************************************************
     /* Overridden methods

--- a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
@@ -91,19 +91,6 @@ public class AnnotationBundleKeyTest
             fail("Annotations Array differ in length");
         }
 
-        for (Annotation annotation1 : anns1) {
-            boolean found = false;
-            for (Annotation annotation2 : anns2) {
-                if (annotation1 == annotation2) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                fail("Annotation " + annotation1 + " not found.");
-            }
-        }
-
         AnnotationBundleKey b1 = new AnnotationBundleKey(anns1, Object.class);
         AnnotationBundleKey b2 = new AnnotationBundleKey(anns2, Object.class);
 

--- a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.jakarta.rs.base.cfg;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,18 +44,23 @@ public class AnnotationBundleKeyTest
 
     public void testWithClassAnnotations() throws Exception
     {
-        _checkWith(Helper.class.getAnnotations(), Helper.class.getAnnotations());
+        Annotation[] annotations = Helper.class.getAnnotations();
+        Arrays.sort(annotations, Comparator.comparing(Annotation::toString));
+        _checkWith(annotations, annotations);
     }
 
     public void testWithMethodAnnotationEquals() throws Exception
     {
+        Annotation[] getXAnnotations = Helper.class.getDeclaredMethod("getX").getAnnotations();
+        Annotation[] altXAnnotations = Helper.class.getDeclaredMethod("altX").getAnnotations();
+        Arrays.sort(getXAnnotations, Comparator.comparing(Annotation::toString));
+        Arrays.sort(altXAnnotations, Comparator.comparing(Annotation::toString));
+
         // First, same method parameters definitely should match
-        _checkWith(Helper.class.getDeclaredMethod("getX").getAnnotations(),
-                Helper.class.getDeclaredMethod("getX").getAnnotations());
+        _checkWith(getXAnnotations, getXAnnotations);
         // but so should annotations from different method as long as
         // same parameters are in same order
-        _checkWith(Helper.class.getDeclaredMethod("getX").getAnnotations(),
-                Helper.class.getDeclaredMethod("altX").getAnnotations());
+        _checkWith(getXAnnotations, altXAnnotations);
     }
 
     public void testWithMethodAnnotationDifferent() throws Exception
@@ -83,13 +90,10 @@ public class AnnotationBundleKeyTest
 
     protected void _checkWith(Annotation[] anns1, Annotation[] anns2) {
         // First, sanity check2 to know we passed non-empty annotations, same by equality
-        if (anns1.length == 0 || anns2.length == 0) {
+        if (anns1.length == 0) {
             fail("Internal error: empty annotation array");
         }
-
-        if (anns1.length != anns2.length) {
-            fail("Annotations Array differ in length");
-        }
+        assertArrayEquals("Internal error: should never differ", anns1, anns2);
 
         AnnotationBundleKey b1 = new AnnotationBundleKey(anns1, Object.class);
         AnnotationBundleKey b2 = new AnnotationBundleKey(anns2, Object.class);

--- a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
@@ -83,10 +83,26 @@ public class AnnotationBundleKeyTest
 
     protected void _checkWith(Annotation[] anns1, Annotation[] anns2) {
         // First, sanity check2 to know we passed non-empty annotations, same by equality
-        if (anns1.length == 0) {
+        if (anns1.length == 0 || anns2.length == 0) {
             fail("Internal error: empty annotation array");
         }
-        assertArrayEquals("Internal error: should never differ", anns1, anns2);
+
+        if (anns1.length != anns2.length) {
+            fail("Annotations Array differ in length");
+        }
+
+        for (Annotation annotation1 : anns1) {
+            boolean found = false;
+            for (Annotation annotation2 : anns2) {
+                if (annotation1 == annotation2) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                fail("Annotation " + annotation1 + " not found.");
+            }
+        }
 
         AnnotationBundleKey b1 = new AnnotationBundleKey(anns1, Object.class);
         AnnotationBundleKey b2 = new AnnotationBundleKey(anns2, Object.class);


### PR DESCRIPTION
The test [AnnotationBundleKeyTest- testWithClassAnnotations](https://github.com/deekshacheruku/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java#L43C1-L46C6) and [AnnotationBundleKeyTest- testWithMethodAnnotationEquals](https://github.com/deekshacheruku/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java#L48C3-L57C6) invokes [AnnotationBundleKey](https://github.com/deekshacheruku/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java#L35C1-L49C6)  which inturn invokes [calcHash](https://github.com/deekshacheruku/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/AnnotationBundleKey.java#L59C1-L70C6) to calculate hashcode. Now test uses [getAnnotations](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/AnnotatedElement.html#getAnnotations--) to get all the annotations from the class, but the documentation does not specify if it returns in the consistent order which makes this test flaky.

Removal of HashCode check:
Change in the ordering or contents of the elements within an array should not change the hash code of the array itself. The hash code of the array remains the same as long as the array object's identity remains the same. However, it's essential to note that if we have a custom class that overrides the hashCode() method and define the hash code calculation based on the contents of elements within an array, then changing the array's ordering can indeed change the hash code of objects of that custom class. Hence so have to remove hashCode check.

We found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

This PR fixes the problem by checking if every element exists in the Annotations list through HashMap. 

You can run the following command to reproduce assertion failures and verify the fix:

`
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations
`

These two lines in test invoke AnnotationBundleKey - [AnnotationBundleKey](https://github.com/deekshacheruku/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java#L91C1-L92C79)

 
Test Environment:

```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version 5.4.0-156-generic
```

Please let me know if you have any concerns or questions.